### PR TITLE
Updated createUiDefinition.json and ha.json

### DIFF
--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -56,7 +56,7 @@
                                 },
                                 {
                                     "label": "PAYG",
-                                    "value": "payg"
+                                    "value": "payg-new"
                                 }
                             ]
                         }

--- a/createUiDefinition.json
+++ b/createUiDefinition.json
@@ -67,22 +67,21 @@
                         "label": "Virtual machine size",
                         "toolTip": "The size of VM to provision.",
                         "recommendedSizes": [
-                            "Standard_D2",
-                            "Standard_D2_v2",
-                            "Standard_A3",
-                            "Standard_F8",
-                            "Standard_F16"
+                            "Standard_F2s_v2",
+                            "Standard_F4s_v2",
+                            "Standard_F8s_v2",
+                            "Standard_F16s_v2",
+                            "Standard_F32s_v2",
+                            "Standard_F64s_v2"
                         ],
                         "constraints": {
-                            "allowedSizes": [
-                                "Standard_D2",
-                                "Standard_D2_v2",
-                                "Standard_A3",
-                                "Standard_F8",
-                                "Standard_F16",
-                                "Standard_A7",
-                                "Standard_D4",
-                                "Standard_D4_v2"
+                            "excludedSizes": [
+                                "Standard_A0",
+                                "Standard_A1",
+                                "Basic_A0",
+                                "Basic_A1",
+                                "Standard_B1s",
+                                "Standard_B1ms"
                             ]
                         },
                         "osPlatform": "Linux",

--- a/ha.json
+++ b/ha.json
@@ -27,7 +27,7 @@
             "defaultValue": "byol",
             "allowedValues": [
                 "byol",
-                "payg"
+                "payg-new"
             ],
             "metadata": {
                 "description": "License type to use."

--- a/ha.json
+++ b/ha.json
@@ -35,7 +35,7 @@
         },
         "vmSize": {
             "type": "string",
-            "defaultValue": "Standard_A3",
+            "defaultValue": "Standard_F2s_v2",
             "metadata": {
                 "description": "Size of the Virtual Machine."
             }


### PR DESCRIPTION
createUiDefinition.json

- Changed marketplace SKU ID for PAYG from "payg" to "payg-new"
- Replaced recommended sizes with Fs_v2 series VMs
- Replaced "allowedSizes" constraint with "excludedSizes"
- Replaced constraint value with unsupported VM sizes to match new constraint condition

ha.json

- Changed marketplace SKU ID for PAYG from "payg" to "payg-new"
- Changed vmSize default value from "Standard_A3" to "Standard_F2s_v2"