### PR TITLE
Modified Azure Automation job to reflect issue found in xg-aa.ps1 

### DIFF
--- a/shared/xg-aa.ps1
+++ b/shared/xg-aa.ps1
@@ -28,13 +28,13 @@ If ($session.Connected) {
     Start-Sleep -s 5
     $SSHStream.WriteLine("mount -o remount,rw /")
     Start-Sleep -s 5
-    $SSHStream.WriteLine("sed -i `"2i echo '200 azurespecialroutes' >> /etc/iproute2/rt_tables`" /scripts/system/clientpref/customization_application_startup.sh")
+    $SSHStream.WriteLine("echo '200 azurespecialroutes' >> /etc/iproute2/rt_tables")
     Start-Sleep -s 5
-	$SSHStream.WriteLine("sed -i `"3i ip route add default via $portagw dev PortA table 200`" /scripts/system/clientpref/customization_application_startup.sh")
+	$SSHStream.WriteLine("sed -i `"2i ip route add default via $portagw dev PortA table 200`" /scripts/system/clientpref/customization_application_startup.sh")
     Start-Sleep -s 5
-    $SSHStream.WriteLine("sed -i `"4i ip rule add from $portaip to 168.63.129.16 table 200`" /scripts/system/clientpref/customization_application_startup.sh")
+    $SSHStream.WriteLine("sed -i `"3i ip rule add from $portaip to 168.63.129.16 table 200`" /scripts/system/clientpref/customization_application_startup.sh")
     Start-Sleep -s 5
-	$SSHStream.WriteLine("sed -i `"5i ip route flush cache`" /scripts/system/clientpref/customization_application_startup.sh")
+	$SSHStream.WriteLine("sed -i `"4i ip route flush cache`" /scripts/system/clientpref/customization_application_startup.sh")
 	Start-Sleep -s 5
 	$SSHStream.WriteLine("reboot")
     Start-Sleep -s 5


### PR DESCRIPTION
Issue caused non-persistence of the iptables entry over reboot causing sporadic route failure for the Azure wireserver IP.
Adjusted xg-aa.ps1 to write persistent entry into /etc/iproute2/rt_tables